### PR TITLE
Update WPScan

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+tests
+.travis
+.idea
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ LABEL org.opencontainers.image.title="secureCodeBox scanner-webserver-wordpress"
     org.opencontainers.image.revision=$COMMIT_ID \
     org.opencontainers.image.created=$BUILD_DATE
 
-ENTRYPOINT ["ruby","/sectools/src/main.rb"]
+ENTRYPOINT ["bundle","exec","ruby","/sectools/src/main.rb"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem "sinatra"
 gem "rest-client"
-gem "wpscan", "3.5.4"
+gem "wpscan", "3.7.5"
 
-gem "ruby-scanner-scaffolding", :git => "https://github.com/secureCodeBox/ruby-scanner-scaffolding.git", :tag => "v1.0.0"
+gem "ruby-scanner-scaffolding", :github => "secureCodeBox/ruby-scanner-scaffolding", :tag => "v1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem "sinatra"
 gem "rest-client"
-gem "wpscan", "3.7.5"
+gem "wpscan", "3.7.6"
 
 gem "ruby-scanner-scaffolding", :github => "secureCodeBox/ruby-scanner-scaffolding", :tag => "v1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.1)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -16,7 +16,7 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    cms_scanner (0.7.1)
+    cms_scanner (0.8.1)
       get_process_mem (~> 0.2.5)
       nokogiri (~> 1.10.4)
       opt_parse_validator (~> 1.8.1)
@@ -31,29 +31,29 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.11.3)
-    ffi (1.11.3-x64-mingw32)
+    ffi (1.12.1)
+    ffi (1.12.1-x64-mingw32)
     get_process_mem (0.2.5)
       ffi (~> 1.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
     mini_portile2 (2.4.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     mustermann (1.0.3)
     netrc (0.11.0)
-    nokogiri (1.10.5)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.5-x64-mingw32)
+    nokogiri (1.10.7-x64-mingw32)
       mini_portile2 (~> 2.4.0)
     opt_parse_validator (1.8.1)
       activesupport (> 4.2, < 6.1.0)
       addressable (>= 2.5, < 2.8)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     rack (2.0.7)
     rack-protection (2.0.5)
       rack
@@ -78,16 +78,16 @@ GEM
     tilt (2.0.9)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    wpscan (3.7.5)
-      cms_scanner (~> 0.7.1)
+    wpscan (3.7.6)
+      cms_scanner (~> 0.8.1)
     xmlrpc (0.3.0)
     yajl-ruby (1.4.1)
-    zeitwerk (2.2.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby
@@ -97,7 +97,7 @@ DEPENDENCIES
   rest-client
   ruby-scanner-scaffolding!
   sinatra
-  wpscan (= 3.7.5)
+  wpscan (= 3.7.6)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,21 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
-    cms_scanner (0.5.2)
-      nokogiri (~> 1.10.0)
-      opt_parse_validator (~> 1.7.3)
-      public_suffix (>= 3.0, < 3.2)
+      zeitwerk (~> 2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    cms_scanner (0.7.1)
+      get_process_mem (~> 0.2.5)
+      nokogiri (~> 1.10.4)
+      opt_parse_validator (~> 1.8.1)
+      public_suffix (>= 3.0, < 4.1)
       ruby-progressbar (~> 1.10.0)
+      sys-proctable (~> 1.2.2)
       typhoeus (~> 1.3.0)
       xmlrpc (~> 0.3)
       yajl-ruby (~> 1.4.1)
@@ -28,27 +31,29 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.11.1)
-    ffi (1.11.1-x64-mingw32)
+    ffi (1.11.3)
+    ffi (1.11.3-x64-mingw32)
+    get_process_mem (0.2.5)
+      ffi (~> 1.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.13.0)
     mustermann (1.0.3)
     netrc (0.11.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.3-x64-mingw32)
+    nokogiri (1.10.5-x64-mingw32)
       mini_portile2 (~> 2.4.0)
-    opt_parse_validator (1.7.3)
-      activesupport (>= 4.2, < 5.3.0)
-      addressable (>= 2.5, < 2.7)
-    public_suffix (3.1.0)
+    opt_parse_validator (1.8.1)
+      activesupport (> 4.2, < 6.1.0)
+      addressable (>= 2.5, < 2.8)
+    public_suffix (4.0.1)
     rack (2.0.7)
     rack-protection (2.0.5)
       rack
@@ -67,6 +72,8 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.5)
       tilt (~> 2.0)
+    sys-proctable (1.2.2)
+      ffi
     thread_safe (0.3.6)
     tilt (2.0.9)
     typhoeus (1.3.1)
@@ -76,10 +83,11 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    wpscan (3.5.4)
-      cms_scanner (~> 0.5.1)
+    wpscan (3.7.5)
+      cms_scanner (~> 0.7.1)
     xmlrpc (0.3.0)
     yajl-ruby (1.4.1)
+    zeitwerk (2.2.1)
 
 PLATFORMS
   ruby
@@ -89,7 +97,7 @@ DEPENDENCIES
   rest-client
   ruby-scanner-scaffolding!
   sinatra
-  wpscan (= 3.5.4)
+  wpscan (= 3.7.5)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/README.md
+++ b/README.md
@@ -102,20 +102,22 @@ Example Output:
 {
   "findings": [
     {
-      "name": "Credentials for Service ssh://192.168.0.1:22 discovered via bruteforce.",
-      "description": "",
-      "location": "ssh://192.168.0.1:22",
-      "category": "Discovered Credentials",
-      "severity": "HIGH",
+      "id": "e132b47a-9f2c-41cd-be9b-95dc948a8bd3",
+      "name": "CMS Wordpress",
+      "description": "CMS Wordpress Information",
+      "category": "CMS Wordpress",
       "osi_layer": "APPLICATION",
+      "severity": "INFORMATIONAL",
+      "reference": {},
       "attributes": {
-        "username": "root",
-        "password": "123456",
-        "ip_address": "192.168.0.1",
-        "port": "22",
-        "protocol": "tcp",
-        "service": "ssh"
-      }
+        "requests_done": "23",
+        "db_update_finished": "",
+        "version": "4.0.29",
+        "start_time": "2020-01-16 15:05:08 +0000",
+        "end_time": "2020-01-16 15:05:14 +0000"
+      },
+      "location": "http://wordpress.example.com",
+      "false_positive": false
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ release: 'https://img.shields.io/github/release/secureCodeBox/scanner-cms-wpscan
 
 WPScan is a free, for non-commercial use, black box WordPress vulnerability scanner written for security professionals and blog maintainers to test the security of their sites.
 
-> NOTE: You need to provide WPSan with an API Token so that it can look up vulnerabilities infos with https://wpvulndb.com. Without the token WPScan will only identify Wordpress Core / Plugin / Theme versions but not if they are actually vulnerable. You can get a free API Token at by registering for an account at https://wpvulndb.com. Using the secureCodeBox WPScans you can specify the token via the `WPVULNDB_API_TOKEN` target attribute, see the example below.
+> NOTE: You need to provide WPSan with an API Token so that it can look up vulnerabilities infos with [https://wpvulndb.com](https://wpvulndb.com). Without the token WPScan will only identify Wordpress Core / Plugin / Theme versions but not if they are actually vulnerable. You can get a free API Token at by registering for an account at [https://wpvulndb.com](https://wpvulndb.com). Using the secureCodeBox WPScans you can specify the token via the `WPVULNDB_API_TOKEN` target attribute, see the example below.
 
 <!-- end -->
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 ---
-title: "WPScan"
-path: "scanner/WPScan"
-category: "scanner"
-usecase: "Wordpress Vulnerability Scanner"
-release: "https://img.shields.io/github/release/secureCodeBox/scanner-cms-wpscan.svg"
-
+title: 'WPScan'
+path: 'scanner/WPScan'
+category: 'scanner'
+usecase: 'Wordpress Vulnerability Scanner'
+release: 'https://img.shields.io/github/release/secureCodeBox/scanner-cms-wpscan.svg'
 ---
 
 ![WPScan Logo](https://raw.githubusercontent.com/wpscanteam/wpscan/gh-pages/images/wpscan_logo.png)
 
 WPScan is a free, for non-commercial use, black box WordPress vulnerability scanner written for security professionals and blog maintainers to test the security of their sites.
 
+> NOTE: You need to provide WPSan with an API Token so that it can look up vulnerabilities infos with https://wpvulndb.com. Without the token WPScan will only identify Wordpress Core / Plugin / Theme versions but not if they are actually vulnerable. You can get a free API Token at by registering for an account at https://wpvulndb.com. Using the secureCodeBox WPScans you can specify the token via the `WPVULNDB_API_TOKEN` target attribute, see the example below.
+
 <!-- end -->
 
 # About
 
-This repository contains a self contained µService utilizing the WPScan scanner for the secureCodeBox project. To learn more about the WPScan scanner itself visit [wpscan.org] or [wpscan.io]. 
+This repository contains a self contained µService utilizing the WPScan scanner for the secureCodeBox project. To learn more about the WPScan scanner itself visit [wpscan.org] or [wpscan.io].
 
 ## WPScan parameters
 
@@ -31,6 +32,7 @@ To hand over supported parameters through api usage, you can set following attri
       "location": "http://your-target.com/",
       "attributes": {
         "WP_STEALTHY": "[true | false]",
+        "WPVULNDB_API_TOKEN": "[wpvulndb.com api token]",
         "WP_ENUMERATE": "[Options]",
         "WP_MAX_DURATION": "[seconds]",
         "WP_THROTTLE": "[milliseconds]",
@@ -75,7 +77,49 @@ Incompatible choices (only one of each group/s can be used):
 ```
 
 ## Example
-Since we currently do not provide a Wordpress test-site we have no example to offer.
+
+Example configuration: (Note that the token isn't actually real 😉)
+
+```json
+[
+  {
+    "name": "wpscan",
+    "context": "Example WPScan",
+    "target": {
+      "name": "Local Wordpress",
+      "location": "http://wordpress.example.com",
+      "attributes": {
+        "WPVULNDB_API_TOKEN": "RVR4GztDG4sZdfYUVsvyX7fGHvFZMXa7plbsoRHssvq"
+      }
+    }
+  }
+]
+```
+
+Example Output:
+
+```json
+{
+  "findings": [
+    {
+      "name": "Credentials for Service ssh://192.168.0.1:22 discovered via bruteforce.",
+      "description": "",
+      "location": "ssh://192.168.0.1:22",
+      "category": "Discovered Credentials",
+      "severity": "HIGH",
+      "osi_layer": "APPLICATION",
+      "attributes": {
+        "username": "root",
+        "password": "123456",
+        "ip_address": "192.168.0.1",
+        "port": "22",
+        "protocol": "tcp",
+        "service": "ssh"
+      }
+    }
+  ]
+}
+```
 
 ## Development
 
@@ -107,11 +151,9 @@ To build the docker container run:
 
 `docker build -t IMAGE_NAME:LABEL .`
 
-
 [![Build Status](https://travis-ci.com/secureCodeBox/scanner-cms-wpscan.svg?branch=master)](https://travis-ci.com/secureCodeBox/scanner-cms-wpscan)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub release](https://img.shields.io/github/release/secureCodeBox/scanner-cms-wpscan.svg)](https://github.com/secureCodeBox/scanner-cms-wpscan/releases/latest)
-
 
 [wpscan.io]: https://wpscan.io/
 [wpscan.org]: https://wpscan.org/

--- a/src/wordpress_configuration.rb
+++ b/src/wordpress_configuration.rb
@@ -27,6 +27,7 @@ class WordpressConfiguration
     config.wordpress_configuration += "--detection-mode #{target.dig('attributes', 'WP_DETECTION_MODE')} " unless !target.dig('attributes', 'WP_DETECTION_MODE')
     config.wordpress_configuration += "--ua #{target.dig('attributes', 'WP_USER_AGENT')} " unless !target.dig('attributes', 'WP_USER_AGENT')
     config.wordpress_configuration += "--headers #{target.dig('attributes', 'WP_HEADERS')} " unless !target.dig('attributes', 'WP_HEADERS')
+    config.wordpress_configuration += "--api-token #{target.dig('attributes', 'WPVULNDB_API_TOKEN')} " unless !target.dig('attributes', 'WPVULNDB_API_TOKEN')
 
 
     config

--- a/tests/wordpress_configuration_test.rb
+++ b/tests/wordpress_configuration_test.rb
@@ -38,14 +38,15 @@ class WordpressConfigurationTest < Test::Unit::TestCase
             "WP_REQUEST_TIMEOUT" => nil,
             "WP_DETECTION_MODE" => nil,
             "WP_USER_AGENT" => nil,
-            "WP_HEADERS" => nil
+            "WP_HEADERS" => nil,
+            "WPVULNDB_API_TOKEN" => "foobar",
         }
     }
     config = WordpressConfiguration.from_target "49bf7fd3-8512-4d73-a28f-608e493cd726", target
 
     assert_equal(
         config.wordpress_configuration,
-        "--enumerate vp,vt,tt,cb,dbe,u1-10,m1-100 "
+        "--enumerate vp,vt,tt,cb,dbe,u1-10,m1-100 --api-token foobar ",
     )
   end
 end


### PR DESCRIPTION
Newer Versions of WPScans require API Tokens to access the wpvulndb.com api.
These changes enable to pass the token to the wpscan securityTest. 